### PR TITLE
Updated SQL Lite references. 

### DIFF
--- a/Amrap.Core/Amrap.Core.csproj
+++ b/Amrap.Core/Amrap.Core.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="sqlite-net-pcl" Version="1.9.141-beta" />
-    <PackageReference Include="SQLitePCLRaw.core" Version="2.1.4" />
+    <PackageReference Include="SQLitePCLRaw.core" Version="2.1.6" />
   </ItemGroup>
 
 </Project>

--- a/Amrap.Core/Infrastructure/DatabaseHandler.cs
+++ b/Amrap.Core/Infrastructure/DatabaseHandler.cs
@@ -6,7 +6,10 @@ namespace Amrap.Core.Infrastructure;
 public class DatabaseHandler
 {
     private const string _dbName = "Amrap.db";
-    private string _databasePath => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), _dbName);
+
+    // Recently changed to use UserProfile instead of MyDocuments due to breaking changes in .NET 8:
+	// https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/getfolderpath-unix#recommended-action
+    private string _databasePath => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), _dbName);
     private SQLiteAsyncConnection _db;
 
     public bool HasInitialized => _db != null;

--- a/Amrap/Amrap.csproj
+++ b/Amrap/Amrap.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0-android33.0</TargetFrameworks>
+        <TargetFrameworks>net8.0-android</TargetFrameworks>
         <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
         <!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
         <OutputType>Exe</OutputType>
@@ -79,7 +79,7 @@
         <PackageReference Include="Bit.BlazorUI" Version="5.1.0" />
         <PackageReference Include="Bit.BlazorUI.Extras" Version="5.4.0" />
         <PackageReference Include="CommunityToolkit.Maui" Version="5.3.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
         <PackageReference Include="System.IO" Version="4.3.0" />
     </ItemGroup>
 


### PR DESCRIPTION
SQLitePCLRaw.core 2.1.7 introduced 'vtable' error so using 2.1.6.